### PR TITLE
Add SteamStatusService test and CI PHP setup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run tests
+        run: vendor/bin/phpunit
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/README.en.md
+++ b/README.en.md
@@ -182,6 +182,18 @@ PORT=8080
 
 ---
 
+## 🧪 Tests
+
+To run the PHPUnit test suite locally you must have **PHP** and **Composer** installed.
+Install the dependencies and run the tests with:
+
+```bash
+composer install
+./vendor/bin/phpunit
+```
+
+---
+
 ## 🧵 Messenger Worker
 
 The `scheduler_default` queue is automatically consumed using `supervisord`.  

--- a/README.md
+++ b/README.md
@@ -182,6 +182,18 @@ PORT=8080
 
 ---
 
+## 🧪 Tests
+
+Pour exécuter la suite de tests PHPUnit en local, installez **PHP** et **Composer**.
+Installez les dépendances puis lancez les tests :
+
+```bash
+composer install
+./vendor/bin/phpunit
+```
+
+---
+
 ## 🧵 Worker Symfony Messenger
 
 La file `scheduler_default` est automatiquement consommée via `supervisord`.  

--- a/tests/Service/SteamStatusServiceTest.php
+++ b/tests/Service/SteamStatusServiceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\Cs2Status;
+use App\Service\SteamStatusService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class SteamStatusServiceTest extends TestCase
+{
+    public function testUpdateCsgoStatusReturnsEntity()
+    {
+        $responseData = [
+            'result' => [
+                'app' => ['version' => 123, 'timestamp' => 456],
+                'matchmaking' => ['online_players' => 100],
+            ],
+        ];
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn($responseData);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('request')
+            ->with('GET', $this->stringContains('ICSGOServers_730'))
+            ->willReturn($response);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())
+            ->method('persist')
+            ->with($this->isInstanceOf(Cs2Status::class));
+        $entityManager->expects($this->once())
+            ->method('flush');
+
+        $service = new SteamStatusService($httpClient, $entityManager, 'key');
+        $status = $service->updateCsgoStatus();
+
+        $this->assertInstanceOf(Cs2Status::class, $status);
+        $this->assertSame(123, $status->getAppVersion());
+        $this->assertSame(456, $status->getAppTimestamp());
+        $this->assertSame($responseData['result'], $status->getRawData());
+        $this->assertNotNull($status->getFetchedAt());
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit test for `SteamStatusService`
- run composer and phpunit in CI
- document how to run tests in English and French READMEs

## Testing
- `composer install` *(fails: ext-simplexml, ext-xml, ext-dom missing)*
- `vendor/bin/phpunit --version` *(fails: dom, xml, xmlwriter missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865623826ec8330bcddfcdf3497773b